### PR TITLE
Use GPIO to power off 3G modem

### DIFF
--- a/3g-watchdog
+++ b/3g-watchdog
@@ -37,7 +37,7 @@ def main():
 
     if has_new_hardware():
         print("newer hardware detected: will reset by cycling modem power")
-        cycle_modem_power()
+        init_modem_power()
         reset = cycle_modem_power
     else:
         print("older hardware detected: will reset by rebooting")
@@ -107,21 +107,27 @@ def has_new_hardware():
     return " -- " not in output
 
 
-def cycle_modem_power():
+def init_modem_power():
     # Late import to simplify testing on developer machines.
     from RPi import GPIO
 
     GPIO.setmode(GPIO.BCM)
     GPIO.setup(MODEM_PIN, GPIO.OUT)
+    set_modem_power(True)
 
-    print("powering modem off")
-    GPIO.output(MODEM_PIN, GPIO.LOW)
 
+def cycle_modem_power():
+    set_modem_power(False)
     print("waiting...")
     time.sleep(5)
+    set_modem_power(True)
 
-    print("powering modem on")
-    GPIO.output(MODEM_PIN, GPIO.HIGH)
+
+def set_modem_power(on):
+    from RPi import GPIO
+
+    print("powering modem " + "on" if on else "off")
+    GPIO.output(MODEM_PIN, GPIO.HIGH if on else GPIO.LOW)
 
 
 def reboot():

--- a/3g-watchdog
+++ b/3g-watchdog
@@ -17,30 +17,31 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
-    
 
 
 import contextlib
 import subprocess
 import time
-import RPi.GPIO as GPIO
 
-MODEM_PIN = 18
-MODEM_NETDEV = 'usb0'
+MODEM_NETDEV = "usb0"
 
-TEST_HOSTS = [
-    "8.8.8.8",
-    "8.8.4.4",
-]
+TEST_HOSTS = ["8.8.8.8", "8.8.4.4"]
 TEST_INTERVAL_SECS = 5 * 60
+
+ATTINY_ADDRESS = 0x04
+MODEM_PIN = 18
 
 
 def main():
     print("running")
-    print("turning on usb modem through PCB")
-    GPIO.setmode(GPIO.BCM)
-    GPIO.setup(MODEM_PIN, GPIO.OUT)
-    GPIO.output(MODEM_PIN, GPIO.HIGH)
+
+    if has_new_hardware():
+        print("newer hardware detected: will reset by cycling modem power")
+        cycle_modem_power()
+        reset = cycle_modem_power
+    else:
+        print("older hardware detected: will reset by rebooting")
+        reset = reboot
 
     with contextlib.suppress(KeyboardInterrupt):
         while running():
@@ -49,8 +50,8 @@ def main():
             if is_defroute_via_dev(MODEM_NETDEV):
                 print("link is using USB modem")
                 if not ping_hosts(TEST_HOSTS):
-                    print("ping tests FAILED, rebooting system")
-                    reboot()
+                    print("ping tests FAILED")
+                    reset()
             else:
                 print("link is not using USB modem")
 
@@ -62,7 +63,7 @@ def running():
 
 def is_defroute_via_dev(netdev):
     output = subprocess.check_output(["ip", "route"], universal_newlines=True)
-    search = ' dev ' + netdev + ' '
+    search = " dev " + netdev + " "
     for line in output.splitlines():
         if line.startswith("default") and search in line:
             return True
@@ -83,24 +84,50 @@ def ping_host(addr):
     try:
         subprocess.check_call(
             [
-                'ping',
-                '-n',
-                '-q',  # no DNS, quiet output
-                '-c1',  # just need one response
-                '-w30',  # wait up to 30s
+                "ping",
+                "-n",
+                "-q",  # no DNS, quiet output
+                "-c1",  # just need one response
+                "-w30",  # wait up to 30s
                 addr,
             ],
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL)
+            stderr=subprocess.DEVNULL,
+        )
     except subprocess.CalledProcessError:
         return False
     return True
 
 
+def has_new_hardware():
+    output = subprocess.check_output(
+        ["i2cdetect", "-y", "1", hex(ATTINY_ADDRESS), hex(ATTINY_ADDRESS)],
+        universal_newlines=True,
+    )
+    return " -- " not in output
+
+
+def cycle_modem_power():
+    # Late import to simplify testing on developer machines.
+    from RPi import GPIO
+
+    GPIO.setmode(GPIO.BCM)
+    GPIO.setup(MODEM_PIN, GPIO.OUT)
+
+    print("powering modem off")
+    GPIO.output(MODEM_PIN, GPIO.LOW)
+
+    print("waiting...")
+    time.sleep(5)
+
+    print("powering modem on")
+    GPIO.output(MODEM_PIN, GPIO.HIGH)
+
+
 def reboot():
-    print('rebooting system')
+    print("rebooting system")
     subprocess.check_call(["/sbin/reboot"])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/3g-watchdog
+++ b/3g-watchdog
@@ -111,6 +111,7 @@ def init_modem_power():
     # Late import to simplify testing on developer machines.
     from RPi import GPIO
 
+    GPIO.setwarnings(False)
     GPIO.setmode(GPIO.BCM)
     GPIO.setup(MODEM_PIN, GPIO.OUT)
     set_modem_power(True)

--- a/3g-watchdog.service
+++ b/3g-watchdog.service
@@ -6,6 +6,7 @@ After=multi-user.target
 Type=simple
 ExecStart=/usr/local/bin/3g-watchdog
 Restart=on-failure
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/3g-watchdog_test.py
+++ b/3g-watchdog_test.py
@@ -16,112 +16,103 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
+import subprocess
+
 import imp
 import pytest
-import subprocess
 
 # Importing like this is necessary to because the source file we're
 # testing starts with a number and doesn't have a .py extension.
-with open('3g-watchdog') as module_file:
+with open("3g-watchdog") as module_file:
     watchdog = imp.load_source("watchdog", "3g-watchdog", module_file)
 
+# Prevent pylint complaining due to pylint fixtures.
+# pylint:disable=redefined-outer-name
 
-def test_not_using_3g(run_once, sleep, is_defroute_via_dev, ping_host, reboot):
+
+def test_not_using_3g(sleep, is_defroute_via_dev, ping_host, reboot):
     is_defroute_via_dev.return_value = False
 
     watchdog.main()
 
     sleep.assert_called_once_with(300)
-    is_defroute_via_dev.assert_called_once_with('usb0')
+    is_defroute_via_dev.assert_called_once_with("usb0")
     assert ping_host.called is False
     assert reboot.called is False
 
 
-def test_ping_ok(run_once, sleep, is_defroute_via_dev, ping_host, reboot):
+def test_ping_ok(sleep, is_defroute_via_dev, ping_host, reboot):
     is_defroute_via_dev.return_value = True
     ping_host.return_value = True
 
     watchdog.main()
 
     sleep.assert_called_once_with(300)
-    is_defroute_via_dev.assert_called_once_with('usb0')
+    is_defroute_via_dev.assert_called_once_with("usb0")
     ping_host.assert_called_once_with("8.8.8.8")
     assert reboot.called is False
 
 
-def test_ping_fails(run_once, sleep, is_defroute_via_dev, ping_host, reboot):
+def test_ping_fails(sleep, is_defroute_via_dev, ping_host, reboot):
     is_defroute_via_dev.return_value = True
     ping_host.return_value = False
 
     watchdog.main()
 
     sleep.assert_called_once_with(300)
-    is_defroute_via_dev.assert_called_once_with('usb0')
+    is_defroute_via_dev.assert_called_once_with("usb0")
     assert ping_host.call_count == 2 * 5  # 2 hosts, 5 retries
     reboot.assert_called_once_with()
 
 
-def test_ping_fails(run_once, sleep, is_defroute_via_dev, ping_host, reboot):
-    is_defroute_via_dev.return_value = True
-    ping_host.return_value = False
-
-    watchdog.main()
-
-    sleep.assert_called_once_with(300)
-    is_defroute_via_dev.assert_called_once_with('usb0')
-    assert ping_host.call_count == 2 * 5  # 2 hosts, 5 retries
-    reboot.assert_called_once_with()
-
-
-def test_some_pings_fail(run_once, sleep, is_defroute_via_dev, ping_host,
-                         reboot):
+def test_some_pings_fail(sleep, is_defroute_via_dev, ping_host, reboot):
     is_defroute_via_dev.return_value = True
     ping_host.side_effect = [False] * 5 + [True] * 50
 
     watchdog.main()
 
     sleep.assert_called_once_with(300)
-    is_defroute_via_dev.assert_called_once_with('usb0')
+    is_defroute_via_dev.assert_called_once_with("usb0")
     assert ping_host.call_count == 5 + 1
     assert reboot.call_count == 0
 
 
 def test_is_defroute_via_dev_no_usb0(check_output):
-    m = check_output.return_value = """\
+    check_output.return_value = """\
 default via 192.168.164.1 dev wlan0  proto static  metric 600
 169.254.0.0/16 dev eth0  scope link  metric 1000 linkdown
 """
-    assert watchdog.is_defroute_via_dev('usb0') is False
+    assert watchdog.is_defroute_via_dev("usb0") is False
 
 
 def test_is_defroute_via_dev_via_usb0(check_output):
-    m = check_output.return_value = """\
+    check_output.return_value = """\
 default via 192.168.164.1 dev usb0  proto static  metric 600
 169.254.0.0/16 dev eth0  scope link  metric 1000 linkdown
 """
-    assert watchdog.is_defroute_via_dev('usb0') is True
+    assert watchdog.is_defroute_via_dev("usb0") is True
 
     # Check alternate ordering
-    m = check_output.return_value = """\
+    check_output.return_value = """\
 169.254.0.0/16 dev eth0  scope link  metric 1000 linkdown
 default via 192.168.164.1 dev usb0  proto static  metric 600
 """
-    assert watchdog.is_defroute_via_dev('usb0') is True
+    assert watchdog.is_defroute_via_dev("usb0") is True
 
 
 def test_is_defroute_via_dev_usb0_not_default(check_output):
-    m = check_output.return_value = """\
+    check_output.return_value = """\
 1.2.3.0/24 via 192.168.164.1 dev usb0  proto static  metric 600
 169.254.0.0/16 dev eth0  scope link  metric 1000 linkdown
 """
-    assert watchdog.is_defroute_via_dev('usb0') is False
+    assert watchdog.is_defroute_via_dev("usb0") is False
 
 
 def test_ping_host(check_call):
     assert watchdog.ping_host("1.2.3.4") is True
 
     check_call.assert_called_once_with(
-        ['ping', '-n', '-q', '-c1', '-w30', '1.2.3.4'],
+        ["ping", "-n", "-q", "-c1", "-w30", "1.2.3.4"],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
@@ -136,14 +127,19 @@ def test_ping_host_failed(check_call):
 def test_reboot(check_call):
     watchdog.reboot()
 
-    check_call.assert_called_once_with(['/sbin/reboot'])
+    check_call.assert_called_once_with(["/sbin/reboot"])
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
+def old_hardware(mocker):
+    m = mocker.patch.object(watchdog, "has_new_hardware", autospec=True)
+    m.return_value = False
+
+
+@pytest.fixture(autouse=True)
 def run_once(mocker):
     m = mocker.patch.object(watchdog, "running", autospec=True)
     m.side_effect = [True, False]
-    return m
 
 
 @pytest.fixture
@@ -168,11 +164,9 @@ def reboot(mocker):
 
 @pytest.fixture
 def check_call(mocker):
-    return mocker.patch.object(
-        watchdog.subprocess, "check_call", autospec=True)
+    return mocker.patch.object(watchdog.subprocess, "check_call", autospec=True)
 
 
 @pytest.fixture
 def check_output(mocker):
-    return mocker.patch.object(
-        watchdog.subprocess, "check_output", autospec=True)
+    return mocker.patch.object(watchdog.subprocess, "check_output", autospec=True)

--- a/3g-watchdog_test.py
+++ b/3g-watchdog_test.py
@@ -17,7 +17,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 import subprocess
-
 import imp
 import pytest
 


### PR DESCRIPTION
Where possible, the 3G modem will be reset by pulling its power
instead of rebooting the whole system. This is likely to be more
effective than rebooting (we see some cases where rebooting doesn't
help) and also avoids interrupting other system activities.

On older hardware without support for resetting the 3G modem, the
preexisting reboot strategy will be used as it often helps.

Also:
- used the Black code formatter over all code
- dealt with all pylint warnings
- use the pytext fixture autouse feature to avoid listing fixtures
  which are required everywhere.