### PR TITLE
Reset 3G modem if present but no connection for some time

### DIFF
--- a/3g-watchdog
+++ b/3g-watchdog
@@ -24,6 +24,7 @@ import subprocess
 import time
 
 MODEM_NETDEV = "usb0"
+MODEM_VENDOR_PRODUCT = "19d2:1405"
 
 TEST_HOSTS = ["8.8.8.8", "8.8.4.4"]
 TEST_INTERVAL_SECS = 5 * 60
@@ -35,7 +36,9 @@ MODEM_PIN = 18
 def main():
     print("running")
 
-    if has_new_hardware():
+    new_hardware = has_new_hardware()
+
+    if new_hardware:
         print("newer hardware detected: will reset by cycling modem power")
         init_modem_power()
         reset = cycle_modem_power
@@ -44,6 +47,7 @@ def main():
         reset = reboot
 
     with contextlib.suppress(KeyboardInterrupt):
+        no_link_count = 0
         while running():
             time.sleep(TEST_INTERVAL_SECS)
 
@@ -52,8 +56,15 @@ def main():
                 if not ping_hosts(TEST_HOSTS):
                     print("ping tests FAILED")
                     reset()
+            elif is_modem_present():
+                if new_hardware:
+                    no_link_count += 1
+                    if no_link_count >= 3:
+                        print("modem detected, but no connection")
+                        reset()
+                        no_link_count = 0
             else:
-                print("link is not using USB modem")
+                print("USB modem not detected")
 
 
 def running():
@@ -105,6 +116,13 @@ def has_new_hardware():
         universal_newlines=True,
     )
     return " -- " not in output
+
+
+def is_modem_present():
+    exitcode = subprocess.call(
+        ["lsusb", "-d", MODEM_VENDOR_PRODUCT], stdout=subprocess.DEVNULL
+    )
+    return exitcode == 0
 
 
 def init_modem_power():

--- a/3g-watchdog_test.py
+++ b/3g-watchdog_test.py
@@ -131,8 +131,14 @@ def test_reboot(check_call):
 
 @pytest.fixture(autouse=True)
 def old_hardware(mocker):
-    m = mocker.patch.object(watchdog, "has_new_hardware", autospec=True)
+    m = mocker.patch.object(watchdog, "has_new_hardware")
     m.return_value = False
+
+
+@pytest.fixture(autouse=True)
+def is_modem_present(mocker):
+    m = mocker.patch.object(watchdog, "is_modem_present")
+    m.return_value = True
 
 
 @pytest.fixture(autouse=True)

--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ This implements a simple service which if a 3G modem is in use it will
 ensure that some internet hosts can be pinged. Generous retries and
 timeouts are used.
 
-If ping tests fail, the 3G modem is assumed to be dead and the system
-is rebooted.
+If ping tests fail, the 3G modem is assumed to be dead and USB modem
+is reset or the system is rebooted (older hardware only).


### PR DESCRIPTION
This should help with cases where a connection has never been
established because the 3G modem is locked up (as opposed to the 3G
interface being up but not being functional). Action is only taken if
the newer PCB is in use (and the power can just be pulled from the 3G
modem) to avoid continual reboots in areas where there's no 3G
coverage.